### PR TITLE
stm32cube: stm32g431: wrong clock setup

### DIFF
--- a/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_utils.c
+++ b/Drivers/STM32G4xx_HAL_Driver/Src/stm32g4xx_ll_utils.c
@@ -325,7 +325,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSI(LL_UTILS_PLLInitTypeDef *UTILS_PLLInitS
     status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
 
     /* Apply definitive AHB prescaler value if necessary */
-    if((status == SUCCESS) && (hpre != 0U))
+    if((status == SUCCESS) && (hpre == LL_RCC_SYSCLK_DIV_1))
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);
@@ -416,7 +416,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
     status = UTILS_EnablePLLAndSwitchSystem(pllfreq, UTILS_ClkInitStruct);
 
     /* Apply definitive AHB prescaler value if necessary */
-    if((status == SUCCESS) && (hpre != 0U))
+    if((status == SUCCESS) && (hpre == LL_RCC_SYSCLK_DIV_1))
     {
       UTILS_ClkInitStruct->AHBCLKDivider = LL_RCC_SYSCLK_DIV_1;
       LL_RCC_SetAHBPrescaler(UTILS_ClkInitStruct->AHBCLKDivider);


### PR DESCRIPTION
When configuring the PLL > 80MHz, an intermediate step is needed
with AHB prescaler set to 2 before setting the actual value.
Then the AHB prescaler 1 must be set, though

Signed-off-by: Francois Ramu <francois.ramu@st.com>

## IMPORTANT INFORMATION 

### Contributor License Agreement (CLA)
* The Pull Request feature will be considered by STMicroelectronics only after a **Contributor License Agreement (CLA)** mechanism has been deployed.
* We are currently working on the set-up of this procedure. 
  


